### PR TITLE
Palo riverbed

### DIFF
--- a/src/main/resources/drivers/Palo-Alto_PAN-OS.js
+++ b/src/main/resources/drivers/Palo-Alto_PAN-OS.js
@@ -67,7 +67,7 @@ var CLI = {
         fail: "Authentication failed - Telnet authentication failure."
     },
     operational: {
-        prompt: /^([A-Za-z\-_0-9.]+@[a-zA-Z0-9._-]+> )$/,
+        prompt: /^([A-Za-z\-_0-9.]+@[a-zA-Z0-9._-]+(\((.*)*\))*> )$/,
         error: /^(Unknown command: .*|Invalid syntax.)/m,
         pager: {
             avoid: "set cli pager off",


### PR DESCRIPTION
Hello,

I corrected the Palo Alto regex use, because it does not work when the PA is in HA and is the slave.

Now, the regex work in both case.

Best regards,
Adrien GANDARIAS