### PR TITLE
Fix SQL query to be more compliant

### DIFF
--- a/src/main/java/onl/netfishers/netshot/RestService.java
+++ b/src/main/java/onl/netfishers/netshot/RestService.java
@@ -6078,7 +6078,7 @@ public class RestService extends Thread {
 		try {
 			@SuppressWarnings("unchecked")
 			List<RsConfigChangeNumberByDateStat> stats = session
-			.createQuery("select count(c) as changeCount, cast(cast(c.changeDate as date) as timestamp) as changeDay from Config c group by cast(c.changeDate as date) order by changeDate desc")
+			.createQuery("select count(c) as changeCount, cast(cast(c.changeDate as date) as timestamp) as changeDay from Config c group by cast(c.changeDate as date) order by changeDay desc")
 			.setMaxResults(7)
 			.setResultTransformer(Transformers.aliasToBean(RsConfigChangeNumberByDateStat.class))
 			.list();


### PR DESCRIPTION
As SQL request change the column name, the order by should use the name new name....

Mysql jdbc driver seems to works without this fix but postgresql  needs new name usage