### PR TITLE
Increase timeout for connection ( 30 seconds ) . Slow devices needs more than 5 seconds

### DIFF
--- a/src/main/java/onl/netfishers/netshot/device/access/Cli.java
+++ b/src/main/java/onl/netfishers/netshot/device/access/Cli.java
@@ -61,7 +61,7 @@ public abstract class Cli {
 	}
 
 	/** The connection timeout. */
-	protected int connectionTimeout = 5000;
+	protected int connectionTimeout = 30000;
 	
 	/**
 	 * Gets the connection timeout.


### PR DESCRIPTION
Increase connection timeout for slow net devices...
Should be a parameter in the future ?