### PR TITLE
Update Cisco_IOS.js

### DIFF
--- a/src/main/resources/drivers/Cisco_IOS.js
+++ b/src/main/resources/drivers/Cisco_IOS.js
@@ -300,7 +300,7 @@ function snapshot(cli, device, config, debug) {
 			device.set("family", "Cisco Catalyst 3550");
 			device.set("networkClass", "SWITCH");
 		}
-		else if (system.match(/.*WS-C35.*/)) {
+		else if (system.match(/.*WS-[CX]35[0124].*/)) {
 			device.set("family", "Cisco Catalyst 3500XL");
 			device.set("networkClass", "SWITCH");
 		}


### PR DESCRIPTION
Regex for 3500-XL Family .
This fix the issue that the 3500 Family take over the 3560 Family.