### PR TITLE
Add support for dynamic configuration of tacacs role mapping

### DIFF
--- a/dist/netshot.conf
+++ b/dist/netshot.conf
@@ -70,6 +70,10 @@ netshot.aaa.maxidletime = 1800
 #netshot.aaa.tacacs.method = chap
 #netshot.aaa.tacacs.method = pap
 #netshot.aaa.tacacs.accounting = true
+#netshot.aaa.tacacs.role.attributename = role
+#netshot.aaa.tacacs.role.adminlevelrole = admin
+#netshot.aaa.tacacs.role.executereadwriterole = execute-read-executereadwrite
+#netshot.aaa.tacacs.role.readwritelevelrole = read-write
 
 # Connection settings
 #netshot.cli.telnet.connectiontimeout = 5000

--- a/dist/netshot.conf
+++ b/dist/netshot.conf
@@ -72,7 +72,7 @@ netshot.aaa.maxidletime = 1800
 #netshot.aaa.tacacs.accounting = true
 #netshot.aaa.tacacs.role.attributename = role
 #netshot.aaa.tacacs.role.adminlevelrole = admin
-#netshot.aaa.tacacs.role.executereadwriterole = execute-read-executereadwrite
+#netshot.aaa.tacacs.role.executereadwriterole = execute-read-write
 #netshot.aaa.tacacs.role.readwritelevelrole = read-write
 
 # Connection settings

--- a/src/main/java/onl/netfishers/netshot/aaa/Tacacs.java
+++ b/src/main/java/onl/netfishers/netshot/aaa/Tacacs.java
@@ -152,13 +152,16 @@ public class Tacacs {
 					String role = authoReply.getValue(roleAttribute);
 					aaaLogger.debug(MarkerFactory.getMarker("AAA"), "The TACACS+ server returned role: {}", role);
 
-					if(role == null) {
-						aaaLogger.warn("No role returned from the tacacs server using the {} attribute, user will be read only", roleAttribute);
-					} else if(role.equals(adminLevelRole)) {
+					if (role == null) {
+						aaaLogger.warn("No role returned from the TACACS+ server for user {} using the {} attribute, user will be read only", username, roleAttribute);
+					}
+					else if(role.equals(adminLevelRole)) {
 						level = UiUser.LEVEL_ADMIN;
-					} else if (role.equals(executeReadWriteLevelRole)) {
+					}
+					else if (role.equals(executeReadWriteLevelRole)) {
 						level = UiUser.LEVEL_EXECUTEREADWRITE;
-					} else if (role.equals(readWriteLevelRole)) {
+					}
+					else if (role.equals(readWriteLevelRole)) {
 						level = UiUser.LEVEL_READWRITE;
 					}
 

--- a/src/main/java/onl/netfishers/netshot/aaa/Tacacs.java
+++ b/src/main/java/onl/netfishers/netshot/aaa/Tacacs.java
@@ -132,6 +132,12 @@ public class Tacacs {
 		try {
 			SessionClient authenSession = client.newSession(SVC.LOGIN, "rest", remoteAddress == null ? "0.0.0.0" : remoteAddress.getIp(), PRIV_LVL.USER.code());
 			AuthenReply authenReply = authenSession.authenticate_ASCII(username, password);
+
+			String roleAttribute = Netshot.getConfig("netshot.aaa.tacacs.role.attributename", "role");
+			String adminLevelRole = Netshot.getConfig("netshot.aaa.tacacs.role.adminlevelrole", "admin");
+			String executeReadWriteLevelRole = Netshot.getConfig("netshot.aaa.tacacs.role.executereadwriterole", "execute-read-write");
+			String readWriteLevelRole = Netshot.getConfig("netshot.aaa.tacacs.role.readwritelevelrole", "read-write");
+
 			if (authenReply.isOK()) {
 				SessionClient authoSession = client.newSession(SVC.LOGIN, "rest", remoteAddress == null ? "0.0.0.0" : remoteAddress.getIp(), PRIV_LVL.USER.code());
 				AuthorReply authoReply = authoSession.authorize(
@@ -143,19 +149,19 @@ public class Tacacs {
 				);
 				if (authoReply.isOK()) {
 					int level = UiUser.LEVEL_READONLY;
-					String role = authoReply.getValue("role");
+					String role = authoReply.getValue(roleAttribute);
 					aaaLogger.debug(MarkerFactory.getMarker("AAA"), "The TACACS+ server returned role: {}", role);
-					switch (role) {
-					case "admin":
+
+					if(role == null) {
+						aaaLogger.warn("No role returned from the tacacs server using the {} attribute, user will be read only", roleAttribute);
+					} else if(role.equals(adminLevelRole)) {
 						level = UiUser.LEVEL_ADMIN;
-						break;
-					case "execute-read-write":
+					} else if (role.equals(executeReadWriteLevelRole)) {
 						level = UiUser.LEVEL_EXECUTEREADWRITE;
-						break;
-					case "read-write":
+					} else if (role.equals(readWriteLevelRole)) {
 						level = UiUser.LEVEL_READWRITE;
-						break;
 					}
+
 					aaaLogger.info(MarkerFactory.getMarker("AAA"), "The user {} passed TACACS+ authentication (with permission level {}).",
 							username, level);
 					UiUser user = new UiUser(username, level);


### PR DESCRIPTION
Currently if the TACACS server doesn't return a role attribute, the user cannot login (`role` == null, throw a `NullPointerException`), this fix this by allowing the user to log-in with read only privileges.

This also allow configuration of the role key and values instead of having them hard-coded