### PR TITLE
Fix consistency in TACACS+ level role keys

### DIFF
--- a/dist/netshot.conf
+++ b/dist/netshot.conf
@@ -72,7 +72,7 @@ netshot.aaa.maxidletime = 1800
 #netshot.aaa.tacacs.accounting = true
 #netshot.aaa.tacacs.role.attributename = role
 #netshot.aaa.tacacs.role.adminlevelrole = admin
-#netshot.aaa.tacacs.role.executereadwriterole = execute-read-write
+#netshot.aaa.tacacs.role.executereadwritelevelrole = execute-read-write
 #netshot.aaa.tacacs.role.readwritelevelrole = read-write
 
 # Connection settings

--- a/src/main/java/onl/netfishers/netshot/aaa/Tacacs.java
+++ b/src/main/java/onl/netfishers/netshot/aaa/Tacacs.java
@@ -135,7 +135,7 @@ public class Tacacs {
 
 			String roleAttribute = Netshot.getConfig("netshot.aaa.tacacs.role.attributename", "role");
 			String adminLevelRole = Netshot.getConfig("netshot.aaa.tacacs.role.adminlevelrole", "admin");
-			String executeReadWriteLevelRole = Netshot.getConfig("netshot.aaa.tacacs.role.executereadwriterole", "execute-read-write");
+			String executeReadWriteLevelRole = Netshot.getConfig("netshot.aaa.tacacs.role.executereadwritelevelrole", "execute-read-write");
 			String readWriteLevelRole = Netshot.getConfig("netshot.aaa.tacacs.role.readwritelevelrole", "read-write");
 
 			if (authenReply.isOK()) {


### PR DESCRIPTION
Just a small fix for the consistency of the parameters names due to the #121 PR