### PR TITLE
FortiOS - Add hostname truncate character

### DIFF
--- a/src/main/resources/drivers/Fortinet_FortiOS.js
+++ b/src/main/resources/drivers/Fortinet_FortiOS.js
@@ -24,7 +24,7 @@
 	name: "FortinetFortiOS", /* Unique identifier of the driver within Netshot. */
 	description: "Fortinet FortiOS", /* Description to be used in the UI. */
 	author: "NetFishers",
-	version: "4.2" /* Version will appear in the Admin tab. */
+	version: "4.3" /* Version will appear in the Admin tab. */
 };
 
 /**
@@ -110,7 +110,7 @@ var CLI = {
 		fail: "Authentication failed - Telnet authentication failure."
 	},
 	basic: { /* The basic FortiOS prompt. */
-		prompt: /^([A-Za-z0-9_\-]+? (\([A-Za-z0-9_\-]+?\) )?[#$] )$/,
+		prompt: /^([A-Za-z0-9_\-\~]+? (\([A-Za-z0-9_\-]+?\) )?[#$] )$/,
 		error: /^(Unknown action|Command fail)/m,
 		pager: { /* 'pager': define how to handle the pager for long outputs. */
 			match: /^--More-- /,


### PR DESCRIPTION
Hello,

On all Fortinet product, the hostname will be truncated on the prompt if it's too long.

So some devices can't be managed by NetShot without the support of the `~` character into the hostname.

> The System Information widget and the get system status CLI command will display the full host name. However, if the host name is longer than 16 characters, the CLI and other places display the host name in a truncated form ending with a tilde ( ~ ) to indicate that additional characters exist, but are not displayed. For example, if the host name is FortiAnalyzer1234567890, the CLI prompt would be FortiAnalyzer123456~#.

Source : https://help.fortinet.com/fa/faz50hlp/56/5-6-1/FMG-FAZ/2400_System_Settings/0200_Dashboard/0405_Changing%20the%20host%20name.htm

---

Some logs :

```
2021-05-03T10:10:45.250295Z Macro 'basic' was called (current mode is 'ssh').
2021-05-03T10:10:45.278327Z About to send the following command:

Hexadecimal:

Expecting one of the following 1 pattern(s) within 120000ms:
^([A-Za-z0-9_\-]+? (\([A-Za-z0-9_\-]+?\) )?[#$] )$
2021-05-03T10:12:45.282612Z I/O exception: Timeout waiting for the command output.
2021-05-03T10:12:45.283087Z The receive buffer is:
FW02-0_MAR02_XXXXXXX~XXX # 
Hexadecimal:
 46 57 30 32 2d 30 5f 4d 41 52 30 32 5f 53 42 4d 44 45 56 45 7e 4d 45 4e 20 23 20
```

Regards