### PR TITLE
Hide NX-OS honor license timer

### DIFF
--- a/src/main/resources/drivers/Cisco_NX-OS.js
+++ b/src/main/resources/drivers/Cisco_NX-OS.js
@@ -235,6 +235,7 @@ function snapshot(cli, device, config) {
 	try {
 		license += cli.command("show license usage");
 		license += cli.command("show license");
+		license = license.replace(/Honor Start .*/mg, "Honor Start <Timer>");
 	}
 	catch (error) {
 	}


### PR DESCRIPTION
When using honor based licenses, NX-OS include in the `show licence usage` a timer of how many hours have passed since the license activation :

Example:
```
sh license usage  | inc Honor
LAN_ENTERPRISE_SERVICES_PKG   No    -   In use             Honor Start 139D 17H
```

This is detected as a change at every snapshot and generate a new revision, this MR hide the timer so only real licensing change would create a new revision.