### PR TITLE
Update Huawei_NE.js

### DIFF
--- a/src/main/resources/drivers/Huawei_NE.js
+++ b/src/main/resources/drivers/Huawei_NE.js
@@ -288,7 +288,7 @@ function snapshot(cli, device, config) {
 		device.add("vrf", match[1]);
 	}
 	
-	var interfaces = cli.findSections(currentConfig, /^interface (.+)/m);
+	var interfaces = cli.findSections(currentConfig, /^interface (.+\.[0-9]+)/m);
 	for (var i in interfaces) {
 		var networkInterface = {
 			name: interfaces[i].match[1],


### PR DESCRIPTION
Updated line 291 as some Huawei interface have additonal info:
Example:
Normal:
interface Eth-Trunk65.601
regex works fine
L2 interface:
interface Eth-Trunk65.701 mode l2
regex wil match al and then addional command ''display interface " + networkInterface.name + " | inc address|line protocol" wil fail and cause driver to fail a snapshot.

The  new regex solved this problem and fixes the driver.