### PR TITLE
Fix random Arbor ArbOS ghost command bug

### DIFF
--- a/src/main/resources/drivers/Arbor_ArbOS.js
+++ b/src/main/resources/drivers/Arbor_ArbOS.js
@@ -99,7 +99,7 @@ function snapshot(cli, device, config) {
 	const execCommand = function (cliHandler, command) {
 		const output = cliHandler.command(command).trim().replace(/\r\n/g, "\n");
 		const lines = output.split("\n");
-		// Sometime, the first line contains the command itself, it so, we remove it and trim() again
+		// Sometime, the first line contains the command itself, if so, we remove it and trim() again
 		if (lines[0].includes(command)) {
 			lines.splice(0, 1);
 			return lines.join("\n").trim();


### PR DESCRIPTION
On many of our production device, Arbor ArbOS would randomly insert the command in the command result, this is a fix for it.

It may be interesting to insert the fix also in the commands run in compliances and others, would making this new function global in the .js and calling is in runCommand works ?