### PR TITLE
Update Cisco_IOS.js

### DIFF
--- a/src/main/resources/drivers/Cisco_IOS.js
+++ b/src/main/resources/drivers/Cisco_IOS.js
@@ -21,7 +21,7 @@ var Info = {
 	name: "CiscoIOS12",
 	description: "Cisco IOS and IOS-XE",
 	author: "NetFishers",
-	version: "1.7.1"
+	version: "1.7.2"
 };
 
 var Config = {
@@ -109,7 +109,7 @@ var CLI = {
 		}
 	},
 	password: {
-		prompt: /^[Pp]assword: $/,
+		prompt: /^[Pp]assword:\s?$/,
 		macros: {
 			auto: {
 				cmd: "$$NetshotPassword$$",


### PR DESCRIPTION
Replaced Line 112:
^[Pp]assword: $

with:
^[Pp]assword:\s?$

Reason:
Some cisco IOS devices have a whitespace after Password: prompt. others don`t.