### PR TITLE
Avocent : Prompts and AutoDiscovery

### DIFF
--- a/src/main/resources/drivers/Avocent_ACS.js
+++ b/src/main/resources/drivers/Avocent_ACS.js
@@ -24,7 +24,7 @@
 	name: "AvocentACS", /* Unique identifier of the driver within Netshot. */
 	description: "Avocent ACS", /* Description to be used in the UI. */
 	author: "NetFishers",
-	version: "1.1" /* Version will appear in the Admin tab. */
+	version: "1.3" /* Version will appear in the Admin tab. */
 };
 
 /**
@@ -110,7 +110,7 @@ var CLI = {
 		}
 	},
 	cli: { /* The basic Avocent prompt. */
-		prompt: /^((\*\*|--):-\s[A-Za-z\.-_\/]+\scli->)(\s)?(\x07)?$/,
+		prompt: /^((\*\*|--)(:-|:#-)\s[a-z\.-_]+\scli->)(\s)?(\x07)?$/,
 		clearPrompt: true,
 		error: /^(Error: .*)/m,
 		pager: { /* 'pager': define how to handle the pager for long outputs. */
@@ -130,6 +130,16 @@ var CLI = {
 			},
 			revert: {
 				cmd: "revert",
+				options: [ "cli" ],
+				target: "cli",
+			},
+			delete: {
+				cmd: "delete -",
+				options: [ "cli" ],
+				target: "cli",
+			},
+			save: {
+				cmd: "save --cancelOnError",
 				options: [ "cli" ],
 				target: "cli",
 			},

--- a/src/main/resources/drivers/Avocent_ACS.js
+++ b/src/main/resources/drivers/Avocent_ACS.js
@@ -335,6 +335,6 @@ function analyzeTrap(trap) {
  * @returns true if the scanned device is supported by this driver.
  */
 function snmpAutoDiscover(sysObjectID, sysDesc) {
-	return !!(sysObjectID.startsWith("1.3.6.1.4.1.10418.16.1.")
-			&& sysDesc.match(/Cyclades ACS/));
+	return !!(sysObjectID.startsWith("1.3.6.1.4.1.10418.")
+			&& sysDesc.match(/^(Cyclades|Avocent) ACS [0-9]{4}$/));
 }


### PR DESCRIPTION
Hello,

This MR update prompt for specific menus like `cd /network/snmp`

- Default prompt : `--:- / cli->`
- Specific prompt : `--:- snmp cli->` or `--:- [snmp] cli->`

And add `delete - ` macro for purge all elements in a specific path or `save --cancelOnError` macro for apply element configuration into a list menu (like iptables or routes)

Regards