### PR TITLE
Add custom nasidentifier if specify in config

### DIFF
--- a/src/main/java/onl/netfishers/netshot/aaa/Radius.java
+++ b/src/main/java/onl/netfishers/netshot/aaa/Radius.java
@@ -44,6 +44,7 @@ import net.jradius.dictionary.Attr_NASPortType;
 import net.jradius.dictionary.Attr_ServiceType;
 import net.jradius.dictionary.Attr_UserName;
 import net.jradius.dictionary.Attr_UserPassword;
+import net.jradius.dictionary.Attr_NASIdentifier;
 import net.jradius.packet.AccessAccept;
 import net.jradius.packet.AccessRequest;
 import net.jradius.packet.RadiusResponse;
@@ -64,6 +65,9 @@ public class Radius {
 	
 	/** The authentication method. */
 	private static Class<? extends RadiusAuthenticator> authMethod = MSCHAPv2Authenticator.class;
+	
+	/** The nasIdentifier */
+	private static String nasIdentifier = null;
 
 	/**
 	 * Load server config.
@@ -140,6 +144,7 @@ public class Radius {
 		default:
 			logger.error("Invalid configured RADIUS method '{}'. Defaulting to MSCHAPv2.", method);
 		}
+		nasIdentifier = Netshot.getConfig("netshot.aaa.radius.nasidentifier", null);
 		clients.add(client);
 	}
 
@@ -178,6 +183,9 @@ public class Radius {
 		attributeList.add(new Attr_UserName(username));
 		attributeList.add(new Attr_NASPortType(Attr_NASPortType.Ethernet));
 		attributeList.add(new Attr_NASPort(1));
+		if (nasIdentifier != null) {
+			attributeList.add(new Attr_NASIdentifier(nasIdentifier));
+		}
 		if (remoteAddress != null) {
 			attributeList.add(new Attr_CallingStationId(remoteAddress.getIp()));
 		}

--- a/src/main/java/onl/netfishers/netshot/device/access/Cli.java
+++ b/src/main/java/onl/netfishers/netshot/device/access/Cli.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2013-2021 Sylvain Cadilhac (NetFishers)
- * 
+ *
  * This file is part of Netshot.
- * 
+ *
  * Netshot is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Netshot is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with Netshot.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -35,11 +35,11 @@ import org.slf4j.LoggerFactory;
  * Abstract - real implementations are Telnet, SSH.
  */
 public abstract class Cli {
-	
+
 	final private static Logger logger = LoggerFactory.getLogger(Cli.class);
-	
+
 	private static Pattern ansiEscapePattern = Pattern.compile("\u001B\\[([;\\d]*m|[\u0030-\u003F]*[\u0020-\u002F]*[\u0040-\u007E])");
-	
+
 	/**
 	 * An IOException, with an attached buffer.
 	 * @author sylvain.cadilhac
@@ -52,18 +52,18 @@ public abstract class Cli {
 			super(message);
 			this.receivedBuffer = receivedBuffer;
 		}
-		
+
 		private StringBuffer receivedBuffer;
-		
+
 		public StringBuffer getReceivedBuffer() {
 			return receivedBuffer;
 		}
-		
+
 	}
 
 	/** The connection timeout. */
 	protected int connectionTimeout = 5000;
-	
+
 	/** The receive timeout. */
 	protected int receiveTimeout = 60000;
 
@@ -72,34 +72,34 @@ public abstract class Cli {
 
 	/** The current task logger */
 	protected TaskLogger taskLogger;
-	
+
 	/** The last command. */
 	protected String lastCommand;
-	
+
 	/** The last expect match. */
 	protected Matcher lastExpectMatch;
-	
+
 	/** The last expect match pattern. */
 	protected String lastExpectMatchPattern;
-	
+
 	/** The last expect match index. */
 	protected int lastExpectMatchIndex = -1;
-	
+
 	/** The last full output. */
 	protected String lastFullOutput;
-	
+
 	/** The in stream. */
 	protected InputStream inStream;
-	
+
 	/** The out stream. */
 	protected PrintStream outStream;
-	
+
 	/** The prompt. */
 	protected String prompt;
-	
+
 	/** The host. */
 	protected NetworkAddress host;
-	
+
 	/**
 	 * Instantiates a new cli.
 	 *
@@ -110,7 +110,7 @@ public abstract class Cli {
 		this.host = host;
 		this.taskLogger = taskLogger;
 	}
-	
+
 	/**
 	 * Gets the connection timeout.
 	 *
@@ -146,7 +146,7 @@ public abstract class Cli {
 	public void setReceiveTimeout(int receiveTimeout) {
 		this.receiveTimeout = receiveTimeout;
 	}
-	
+
 	/**
 	 * Gets the command timeout.
 	 *
@@ -164,7 +164,7 @@ public abstract class Cli {
 	public void setCommandTimeout(int commandTimeout) {
 		this.commandTimeout = commandTimeout;
 	}
-	
+
 	/**
 	 * Gets the last command.
 	 *
@@ -182,7 +182,7 @@ public abstract class Cli {
 	public Matcher getLastExpectMatch() {
 		return lastExpectMatch;
 	}
-	
+
 	/**
 	 * Gets the last expect match pattern.
 	 *
@@ -191,7 +191,7 @@ public abstract class Cli {
 	public String getLastExpectMatchPattern() {
 		return lastExpectMatchPattern;
 	}
-	
+
 	/**
 	 * Gets the last expect match index.
 	 *
@@ -200,7 +200,7 @@ public abstract class Cli {
 	public int getLastExpectMatchIndex() {
 		return lastExpectMatchIndex;
 	}
-	
+
 	/**
 	 * Gets the last full output.
 	 *
@@ -216,7 +216,7 @@ public abstract class Cli {
 	 * @throws IOException Signals that an I/O exception has occurred.
 	 */
 	public abstract void connect() throws IOException;
-	
+
 	/**
 	 * Send.
 	 *
@@ -230,7 +230,7 @@ public abstract class Cli {
 		expects[0] = expect;
 		return send(command, expects);
 	}
-	
+
 	/**
 	 * Disconnect.
 	 */
@@ -250,9 +250,9 @@ public abstract class Cli {
 		for (int i = 0; i < expects.length; i++) {
 			patterns[i] = Pattern.compile(expects[i], Pattern.MULTILINE);
 		}
-		
+
 		long lastActivityTime = System.currentTimeMillis();
-		
+
 		while (true) {
 			while (this.inStream != null && this.inStream.available() > 0) {
 				int length = this.inStream.read(miniBuffer);
@@ -304,6 +304,6 @@ public abstract class Cli {
 		this.lastCommand = command;
 		return this.readUntil(expects);
 	}
-	
+
 
 }

--- a/src/main/java/onl/netfishers/netshot/device/access/Telnet.java
+++ b/src/main/java/onl/netfishers/netshot/device/access/Telnet.java
@@ -1,18 +1,18 @@
 /**
  * Copyright 2013-2021 Sylvain Cadilhac (NetFishers)
- * 
+ *
  * This file is part of Netshot.
- * 
+ *
  * Netshot is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * Netshot is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License
  * along with Netshot.  If not, see <http://www.gnu.org/licenses/>.
  */
@@ -33,29 +33,53 @@ import org.slf4j.LoggerFactory;
  * A Telnet CLI access.
  */
 public class Telnet extends Cli {
-	
+
 	final private static Logger logger = LoggerFactory.getLogger(Ssh.class);
 
-	/** Default value for the SSH connection timeout */
+	/** Default value for the Telnet connection timeout */
 	static private int DEFAULT_CONNECTION_TIMEOUT = 5000;
+
+	/** Default value for the Telnet receive timeout */
+	static private int DEFAULT_RECEIVE_TIMEOUT = 60000;
+
+	/** Default value for the Telnet command timeout */
+	static private int DEFAULT_COMMAND_TIMEOUT = 120000;
 
 	static {
 		int configuredConnectionTimeout = Netshot.getConfig("netshot.cli.telnet.connectiontimeout", DEFAULT_CONNECTION_TIMEOUT);
 		if (configuredConnectionTimeout < 1) {
-			logger.error("Invalid value {} for {}", configuredConnectionTimeout, "netshot.cli.telnet.connectiontimeout");			
+			logger.error("Invalid value {} for {}", configuredConnectionTimeout, "netshot.cli.telnet.connectiontimeout");
 		}
 		else {
 			DEFAULT_CONNECTION_TIMEOUT = configuredConnectionTimeout;
 		}
 		logger.info("The default connection timeout value for Telnet sessions is {}s", DEFAULT_CONNECTION_TIMEOUT);
+
+		int configuredReceiveTimeout = Netshot.getConfig("netshot.cli.telnet.receivetimeout", DEFAULT_RECEIVE_TIMEOUT);
+		if (configuredReceiveTimeout < 1) {
+			logger.error("Invalid value {} for {}", configuredReceiveTimeout, "netshot.cli.telnet.receivetimeout");
+		}
+		else {
+			DEFAULT_RECEIVE_TIMEOUT = configuredReceiveTimeout;
+		}
+		logger.info("The default receive timeout value for Telnet sessions is {}s", DEFAULT_RECEIVE_TIMEOUT);
+
+		int configuredCommandTimeout = Netshot.getConfig("netshot.cli.telnet.commandtimeout", DEFAULT_COMMAND_TIMEOUT);
+		if (configuredCommandTimeout < 1) {
+			logger.error("Invalid value {} for {}", configuredCommandTimeout, "netshot.cli.telnet.commandtimeout");
+		}
+		else {
+			DEFAULT_COMMAND_TIMEOUT = configuredCommandTimeout;
+		}
+		logger.info("The default command timeout value for Telnet sessions is {}s", DEFAULT_COMMAND_TIMEOUT);
 	}
 
 	/** The port. */
 	private int port = 23;
-	
+
 	/** The telnet. */
 	private TelnetClient telnet = null;
-	
+
 	/**
 	 * Instantiates a new telnet.
 	 *
@@ -65,7 +89,7 @@ public class Telnet extends Cli {
 	public Telnet(NetworkAddress host, TaskLogger taskLogger) {
 		super(host, taskLogger);
 	}
-	
+
 	/**
 	 * Instantiates a new telnet.
 	 *
@@ -77,8 +101,10 @@ public class Telnet extends Cli {
 		this(host, taskLogger);
 		if (port != 0) this.port = port;
 		this.connectionTimeout = DEFAULT_CONNECTION_TIMEOUT;
+		this.commandTimeout = DEFAULT_COMMAND_TIMEOUT;
+		this.receiveTimeout = DEFAULT_RECEIVE_TIMEOUT;
 	}
-	
+
 	/* (non-Javadoc)
 	 * @see onl.netfishers.netshot.device.access.Cli#connect()
 	 */
@@ -102,6 +128,6 @@ public class Telnet extends Cli {
 		} catch (Exception e) {
 		}
 	}
-	
-	
+
+
 }


### PR DESCRIPTION
Add attribute nas Identifier in radius request if a nas identifier is specify in the config file like example below, do nothing otherwise
netshot.aaa.radius.nasidentifier = netshotid

Needed because multiple radius client behind a NAT and connot be identified without this nasidentifier

Compile and tested, already working on our server.

I am not a java dev or dev as well, i try to make something clean but maybe miss something feel free to comment