### PR TITLE
Update systemd-netshot with AmbientCapabilities

### DIFF
--- a/dist/systemd-netshot
+++ b/dist/systemd-netshot
@@ -7,6 +7,7 @@ Type=simple
 ExecStart=/usr/bin/java -jar /usr/local/netshot/netshot.jar
 ExecReload=/bin/kill -HUP $MAINPID
 User=netshot
+AmbientCapabilities=CAP_NET_BIND_SERVICE
 
 [Install]
 Alias=netshot


### PR DESCRIPTION
If you want the service to listen on privileged ports when starting the service as unprivileged user, it is better to use systemd's built-in functionality than scripts in if-up.d

https://www.freedesktop.org/software/systemd/man/systemd.exec.html#AmbientCapabilities=