### PR TITLE
Added oldLineParents index validation

### DIFF
--- a/src/main/java/onl/netfishers/netshot/rest/RestService.java
+++ b/src/main/java/onl/netfishers/netshot/rest/RestService.java
@@ -1319,10 +1319,12 @@ public class RestService extends Thread {
 						allOldLines.size() - 1));
 			this.hierarchy = new ArrayList<>();
 			int p = this.originalPosition;
+			if (p < oldLineParents.length) {
 			p = oldLineParents[p];
-			while (p >= 0) {
-				this.hierarchy.add(new LineWithPosition(allOldLines.get(p), p));
-				p = oldLineParents[p];
+				while (p >= 0) {
+					this.hierarchy.add(new LineWithPosition(allOldLines.get(p), p));
+					p = oldLineParents[p];
+				}
 			}
 			Collections.reverse(this.hierarchy);
 		}

--- a/src/main/java/onl/netfishers/netshot/rest/RestService.java
+++ b/src/main/java/onl/netfishers/netshot/rest/RestService.java
@@ -1320,7 +1320,7 @@ public class RestService extends Thread {
 			this.hierarchy = new ArrayList<>();
 			int p = this.originalPosition;
 			if (p < oldLineParents.length) {
-			p = oldLineParents[p];
+				p = oldLineParents[p];
 				while (p >= 0) {
 					this.hierarchy.add(new LineWithPosition(allOldLines.get(p), p));
 					p = oldLineParents[p];


### PR DESCRIPTION
Added oldLineParents index validation to prevent ArrayIndexOutOfBoundsException when p exceeds the maximum index of the oldLineParents int array.

Issue: https://github.com/netfishers-onl/Netshot/issues/254