### PR TITLE
Update Juniper_Junos.js

### DIFF
--- a/src/main/resources/drivers/Juniper_Junos.js
+++ b/src/main/resources/drivers/Juniper_Junos.js
@@ -177,7 +177,7 @@ function snapshot(cli, device, config) {
 		device.set("name", hostname[1]);
 	}
 	
-	var version = showVersion.match(/^JUNOS .* \[(.*)\]/m);
+	var version = showVersion.match(/^?<=Junos[:\s]+)(\d+\.\d+([A-Za-z]?\d+)(?:[-\.]?[A-Za-z0-9]+)*/mi);
 	if (version != null) {
 		device.set("softwareVersion", version[1]);
 		config.set("junosVersion", version[1]);

--- a/src/main/resources/drivers/Juniper_Junos.js
+++ b/src/main/resources/drivers/Juniper_Junos.js
@@ -177,7 +177,7 @@ function snapshot(cli, device, config) {
 		device.set("name", hostname[1]);
 	}
 	
-	var version = showVersion.match(/^?<=Junos[:\s]+)(\d+\.\d+([A-Za-z]?\d+)(?:[-\.]?[A-Za-z0-9]+)*/mi);
+	var version = showVersion.match(/?<=Junos[:\s]+)(\d+\.\d+([A-Za-z]?\d+)(?:[-\.]?[A-Za-z0-9]+)*/mi);
 	if (version != null) {
 		device.set("softwareVersion", version[1]);
 		config.set("junosVersion", version[1]);


### PR DESCRIPTION
Modified regex to capture the version number to allow for compatibility with the output of the "show version" command on newer switches, while still working for the older format.

For reference, on older versions of JunOS the output was as follows:

fpc0:
--------------------------------------------------------------------------
Hostname: Hostname
Model: ex2200-24p-4g
JUNOS Base OS boot [12.3R9.4]
JUNOS Base OS Software Suite [12.3R9.4]
JUNOS Kernel Software Suite [12.3R9.4]
etc...

On newer version it looks like this:

fpc0:
--------------------------------------------------------------------------
Hostname: Hostname
Model: ex2300-c-12p
Junos: 21.2R1.11
JUNOS OS Kernel 32-bit  [20210709.5ccb29e_builder_stable_12_212]
JUNOS OS libs [20210709.5ccb29e_builder_stable_12_212]
JUNOS OS runtime [20210709.5ccb29e_builder_stable_12_212]
etc...

With the existing regex this means the version displayed in Netshot was the build number in the square brackets. With this new expression it will grab the Junos version number instead.