### PR TITLE
NX OS also allows for switchname command instead of hostname.

### DIFF
--- a/src/main/resources/drivers/Cisco_ACI-APIC.js
+++ b/src/main/resources/drivers/Cisco_ACI-APIC.js
@@ -1,0 +1,373 @@
+/**
+ * Copyright 2013-2025 Netshot
+ * 
+ * This file is part of Netshot project.
+ * 
+ * Netshot is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ * 
+ * Netshot is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with Netshot.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * 
+ * Cisco ACI APIC driver
+ * In Cisco ACI the APIC is the controller(s), and devices that are controlled by them no longer 
+ * operate as normal NX-OS devices, the entire configuration for the fabric is kept in the 
+ * controllers, but they are also not "normal" network devices, so some shenanigans are needed
+ * to get the data out.
+ */
+
+var Info = {
+	name: "CiscoACIAPIC",
+	description: "Cisco ACI APIC controller",
+	author: "Anders",
+	version: "0.9.0",
+};
+
+var Config = {
+	"systemImageFile": {
+		type: "Text",
+		title: "System image file",
+		comparable: true,
+		searchable: true,
+		checkable: true
+	},
+	"runningConfig": {
+		type: "LongText",
+		title: "Running configuration",
+		comparable: true,
+		searchable: true,
+		checkable: true,
+		dump: {
+			pre: "!! Running configuration (taken on %when%):",
+			post: "!! End of running configuration"
+		}
+	},
+	"ACILicense": {
+		type: "LongText",
+		title: "License",
+		comparable: true,
+		searchable: false,
+		checkable: true,
+		dump: {
+			pre: "!! License information:",
+			post: "!! End of license information",
+			preLine: "!! "
+		}
+	},
+	"ACIVersions": {
+		type: "LongText",
+		title: "ACI Fabric software version",
+		comparable: true,
+		searchable: true,
+		checkable: true,
+		dump: {
+			pre: "!! ACI Fabric software version:",
+			preLine: "!!  ",
+			post: "!! End of ACI Fabric software version"
+		}
+	},
+};
+
+var Device = {
+	"memorySize": {
+		type: "Numeric",
+		title: "Memory size (MB)",
+		searchable: true
+	},
+	"flashSize": {
+		type: "Numeric",
+		title: "Flash size (MB)",
+		searchable: true
+	},
+	"configurationSaved": {
+		type: "Binary",
+		title: "Configuration saved",
+		searchable: true
+	}
+	"FabricName": {
+		type: "Text",
+		title: "Fabric name",
+		searchable: true
+	},
+	"FabricSize": {
+		type: "Text",
+		title: "Fabric size",
+		searchable: true
+	},
+	"InbandIPv4": {
+		type: "Text",
+		title: "Inband IPv4 address",
+		searchable: true
+	},
+	"InbandIPv6": {
+		type: "Text",
+		title: "Inband IPv6 address",
+		searchable: true
+	},
+	"OutbandIPv4": {
+		type: "Text",
+		title: "Outband IPv4 address",
+		searchable: true
+	},
+	"OutbandIPv6": {
+		type: "Text",
+		title: "Outband IPv6 address",
+		searchable: true
+	},
+	"CertificateStatus": {
+		type: "Text",
+		title: "Certificate status",
+		searchable: true
+	},
+	"CertificateEndDate": {
+		type: "Text",
+		title: "Certificate end date",
+		searchable: true
+	},
+};
+
+var CLI = {
+	telnet: {
+		macros: {
+			exec: {
+				options: [ "username", "password", "exec" ],
+				target: "exec"
+			},
+			configure: {
+				options: [ "username", "password", "exec" ],
+				target: "configure"
+			}
+		}
+	},
+	ssh: {
+		macros: {
+			exec: {
+				options: [ "exec" ],
+				target: "exec"
+			},
+			configure: {
+				options: [ "exec" ],
+				target: "configure"
+			}
+		}
+	},
+	username: {
+		prompt: /^login: $/,
+		macros: {
+			auto: {
+				cmd: "$$NetshotUsername$$",
+				options: [ "password" ]
+			}
+		}
+	},
+	password: {
+		prompt: /^Password: $/,
+		macros: {
+			auto: {
+				cmd: "$$NetshotPassword$$",
+				options: [ "usernameAgain", "exec" ]
+			}
+		}
+	},
+	usernameAgain: {
+		prompt: /^login: $/,
+		fail: "Authentication failed - Telnet authentication failure."
+	},
+	exec: {
+		prompt: /^([A-Za-z\-_0-9\.]+#) $/,
+		error: /^% (.*)/m,
+		pager: {
+			avoid: "terminal length 0",
+			match: /^ --More--$/,
+			response: " "
+		},
+		macros: {
+			configure: {
+				cmd: "configure terminal",
+				options: [ "exec", "configure" ],
+				target: "configure"
+			},
+			save: {
+				cmd: "copy running-config startup-config",
+				options: [ "exec" ],
+				target: "exec"
+			},
+			saveAll: {
+				cmd: "copy running-config startup-config vdc-all",
+				options: [ "exec" ],
+				target: "exec"
+			},
+		}
+
+	},
+	configure: {
+		prompt: /^([A-Za-z\-_0-9\.]+\(conf[0-9\-a-zA-Z]+\)#) $/,
+		error: /^% (.*)/m,
+		clearPrompt: true,
+		macros: {
+			end: {
+				cmd: "end",
+				options: [ "exec", "configure" ],
+				target: "exec"
+			}
+		}
+	}
+};
+
+function snapshot(cli, device, config) {
+	
+	// in the controller status we are looking for the controller marked with a "*", that is the one we are logged in to, 
+	// it is its number followed by "*", so if we are on controller 1, "1*" will be the line, if we are on controller 2, "2*" will the one.
+
+	var controllerStatus = cli.command("show controller");
+	var controllerId = controllerStatus.match(/^\s+([0-9]+)\*.*$/m);
+	if (controllerId) {
+		controllerId = controllerId[1];
+	} else {
+		cli.debug("No controller marked with a * in the output of 'show controller', assuming we are on controller 1");
+		controllerId = 1; // assume 1 if not, since you need to have at least one controller.
+	}
+
+	// we also want to have the fabric name, and sizes. 
+	var fabricName = controllerStatus.match(/^\s*Fabric Name *: (.*)$/m);
+	var fabricSize = controllerStatus.match(/^\s*Operational Size *: (.*)$/m);
+	if (fabricName) {
+		fabricName = fabricName[1];
+	} else {
+		cli.debug("No fabric name in the output of 'show controller', assuming default");
+		fabricName = "Default";
+	}
+	if (fabricSize) {
+		fabricSize = fabricSize[1];
+	} else {
+		cli.debug("No fabric size in the output of 'show controller', assuming default");
+		fabricSize = 1;
+	}
+
+	// get Controller status in detatils. 
+	var controllerStatus = cli.command("show controller detail id " + controllerId);
+	var name = controllerStatus.match(/^\s*Name *: (.*)$/m);
+	var address = controllerStatus.match(/^\s*Address *: (.*)$/m);
+	var inbandIPv4 = controllerStatus.match(/^\s*In-Band IPv4 Address *: (.*)$/m);
+	var inbandIPv6 = controllerStatus.match(/^\s*In-Band IPv6 Address *: (.*)$/m);
+	var outbandIPv4 = controllerStatus.match(/^\s*OOB IPv4 Address *: (.*)$/m);
+	var outbandIPv6 = controllerStatus.match(/^\s*OOB IPv6 Address *: (.*)$/m);
+	var serialNumber = controllerStatus.match(/^\s*Serial Number *: (.*)$/m);
+	var version = controllerStatus.match(/^\s*Version *: (.*)$/m);
+	var CertificateStatus = controllerStatus.match(/^\s*Valid Certificate *: (.*)$/m);
+	var CertificateEndDate = controllerStatus.match(/^\s*Validity End *: (.*)$/m);
+
+	if (name) {
+		device.set("name", name[1]);
+	}
+	if (inbandIPv4) {
+		device.set("InbandIPv4", inbandIPv4[1]);
+	}
+	if (inbandIPv6) {
+		device.set("InbandIPv6", inbandIPv6[1]);
+	}
+	if (outbandIPv4) {
+		device.set("OutbandIPv4", outbandIPv4[1]);
+	}
+	if (outbandIPv6) {
+		device.set("OutbandIPv6", outbandIPv6[1]);
+	}
+	if (serialNumber) {
+		device.set("serialNumber", serialNumber[1]);
+	}
+	if (CertificateStatus) {
+		device.set("CertificateStatus", CertificateStatus[1]);
+	}
+	if (CertificateEndDate) {
+		device.set("CertificateEndDate", CertificateEndDate[1]);
+	}
+	if (serialNumber) {
+		device.set("serialNumber", serialNumber[1]);
+	}
+	if (version) {
+		device.set("softwareVersion", version[1]);
+	}
+
+
+
+
+	device.set("networkClass", "SWITCH");
+	device.set("family", "Unknown NX-OS device");
+	var chassis = showVersion.match(/cisco (.*?)( \(.*\))? [cC]hassis/m);
+	if (chassis) {
+		var chassis = chassis[1];
+		chassis = chassis.replace(/(Nexus)([0-9].*)/, "$1 $2");
+		device.set("family", chassis);
+	}
+			
+	var licensestatus = cli.command("show license all");
+	config.set("ACILicense", licensestatus);
+	
+	var configCleanup = function(config) {
+		var p = config.search(/^[a-z]/m);
+		if (p > 0) {
+			config = config.slice(p);
+		}
+		config = config.replace(/^\!Time.*$/mg, "");
+		return config;
+	};
+	
+	
+	var runningConfig;
+	try {
+		runningConfig = cli.command("show running-config");
+	}
+	catch (error) {
+		cli.debug("Error getting running config");
+	}
+	var runningDate = NaN;
+	var runningDateMatch = runningConfig.match(/^# Time: (.+)/m);
+	if (runningDateMatch) {
+		runningDate = Date.parse(runningDateMatch[1]);
+	}
+	runningConfig = configCleanup(runningConfig);
+	config.set("runningConfig", runningConfig);
+	if (!isNaN(runningDate)) {
+		device.set("configurationSaved", runningDate);
+	} else {
+		device.set("configurationSaved", false);
+	}
+	
+};
+
+function runCommands(command) {
+	
+}
+
+function analyzeSyslog(message) {
+	if (message.match(/%VSHD-5-VSHD_SYSLOG_CONFIG_I: Configured from (.*) by (.*) on .*/)) {
+		return true;
+	}
+	return false;
+}
+
+function analyzeTrap(trap, debug) {
+	for (var t in trap) {
+		if (trap[t].substring(0, 24) == "1.3.6.1.4.1.9.9.43.2.0.2" || t.substring(0, 24) == "1.3.6.1.4.1.9.9.43.1.1.1") {
+			return true;
+		}
+	}
+	return false;
+}
+
+function snmpAutoDiscover(sysObjectID, sysDesc) {
+	if (sysObjectID.substring(0, 17) == "1.3.6.1.4.1.9.12." && sysDesc.match(/^Cisco NX-OS.*/)) {
+		return true;
+	}
+	return false;
+}

--- a/src/main/resources/drivers/Cisco_NX-OS.js
+++ b/src/main/resources/drivers/Cisco_NX-OS.js
@@ -313,8 +313,7 @@ function snapshot(cli, device, config) {
 	if (hostname) {
 		device.set("name", hostname[1]);
 	} else {
-		### you can also use switchname in NX-OS, to do the same thing as hostname
-		### https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/93x/fundamentals/configuration/guide/b-cisco-nexus-9000-nx-os-fundamentals-configuration-guide-93x/b-cisco-nexus-9000-nx-os-fundamentals-configuration-guide-93x_chapter_01000.html#con_1229065
+		//You can also use switchname in NX-OS, to do the same thing as hostname, so lets check for it.
 		hostname = runningConfig.match(/^switchname (.+)$/m);
 		if (hostname) {
 			device.set("name", hostname[1]);

--- a/src/main/resources/drivers/Cisco_NX-OS.js
+++ b/src/main/resources/drivers/Cisco_NX-OS.js
@@ -21,7 +21,7 @@ var Info = {
 	name: "CiscoNXOS",
 	description: "Cisco NX-OS 5+",
 	author: "Netshot Team",
-	version: "1.9.1"
+	version: "1.9.2"
 };
 
 var Config = {
@@ -312,6 +312,13 @@ function snapshot(cli, device, config) {
 	var hostname = runningConfig.match(/^hostname (.+)$/m);
 	if (hostname) {
 		device.set("name", hostname[1]);
+	} else {
+		### you can also use switchname in NX-OS, to do the same thing as hostname
+		### https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/93x/fundamentals/configuration/guide/b-cisco-nexus-9000-nx-os-fundamentals-configuration-guide-93x/b-cisco-nexus-9000-nx-os-fundamentals-configuration-guide-93x_chapter_01000.html#con_1229065
+		hostname = runningConfig.match(/^switchname (.+)$/m);
+		if (hostname) {
+			device.set("name", hostname[1]);
+		}
 	}
 	
 	var vdcConfigs = runningConfig.split(/[\r\n]+\!Running config for vdc: .*[\r\n]+/);


### PR DESCRIPTION
Hi, 

A simple fix to add support for checking for switchname if there is no hostname set, since that is also a command that does the same thing: https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/93x/fundamentals/configuration/guide/b-cisco-nexus-9000-nx-os-fundamentals-configuration-guide-93x/b-cisco-nexus-9000-nx-os-fundamentals-configuration-guide-93x_chapter_01000.html#con_1229065

