### PR TITLE
NX OS allows for the use of switchname along with hostname

### DIFF
--- a/src/main/resources/drivers/Cisco_NX-OS.js
+++ b/src/main/resources/drivers/Cisco_NX-OS.js
@@ -313,8 +313,7 @@ function snapshot(cli, device, config) {
 	if (hostname) {
 		device.set("name", hostname[1]);
 	} else {
-		### you can also use switchname in NX-OS, to do the same thing as hostname
-		### https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/93x/fundamentals/configuration/guide/b-cisco-nexus-9000-nx-os-fundamentals-configuration-guide-93x/b-cisco-nexus-9000-nx-os-fundamentals-configuration-guide-93x_chapter_01000.html#con_1229065
+		//You can also use switchname in NX-OS, to do the same thing as hostname, so lets check for it.
 		hostname = runningConfig.match(/^switchname (.+)$/m);
 		if (hostname) {
 			device.set("name", hostname[1]);

--- a/src/main/resources/drivers/Cisco_NX-OS.js
+++ b/src/main/resources/drivers/Cisco_NX-OS.js
@@ -21,7 +21,7 @@ var Info = {
 	name: "CiscoNXOS",
 	description: "Cisco NX-OS 5+",
 	author: "Netshot Team",
-	version: "1.9.1"
+	version: "1.9.2"
 };
 
 var Config = {
@@ -312,6 +312,13 @@ function snapshot(cli, device, config) {
 	var hostname = runningConfig.match(/^hostname (.+)$/m);
 	if (hostname) {
 		device.set("name", hostname[1]);
+	} else {
+		### you can also use switchname in NX-OS, to do the same thing as hostname
+		### https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/93x/fundamentals/configuration/guide/b-cisco-nexus-9000-nx-os-fundamentals-configuration-guide-93x/b-cisco-nexus-9000-nx-os-fundamentals-configuration-guide-93x_chapter_01000.html#con_1229065
+		hostname = runningConfig.match(/^switchname (.+)$/m);
+		if (hostname) {
+			device.set("name", hostname[1]);
+		}
 	}
 	
 	var vdcConfigs = runningConfig.split(/[\r\n]+\!Running config for vdc: .*[\r\n]+/);


### PR DESCRIPTION
Hi, 

The original PR was created from the wrong branch, so deleted and re-created. 

NX OS allows you to use the switchname command in addition to hostname, it does the same thing, so look for switchname in NX driver if there is no hostname found. 

Cisco ref: 
https://www.cisco.com/c/en/us/td/docs/switches/datacenter/nexus9000/sw/93x/fundamentals/configuration/guide/b-cisco-nexus-9000-nx-os-fundamentals-configuration-guide-93x/b-cisco-nexus-9000-nx-os-fundamentals-configuration-guide-93x_chapter_01000.html#task_1236060