### PR TITLE
feat(Dockerfile): download graalpy's standalone build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 ARG NETSHOT_VERSION=0.0.1-dev
 ARG GRAALVM_VERSION=21.0.6
+ARG GRAALPY_VERSION=24.2.1
 
 FROM debian:12 AS debian-graalvm
 ARG GRAALVM_VERSION
+ARG GRAALPY_VERSION
 RUN apt-get -y update && apt-get -y install wget fontconfig
 WORKDIR /usr/lib/jvm
 RUN wget --quiet https://download.oracle.com/graalvm/${GRAALVM_VERSION%%.*}/archive/graalvm-jdk-${GRAALVM_VERSION}_linux-x64_bin.tar.gz && \ 
@@ -11,6 +13,10 @@ RUN wget --quiet https://download.oracle.com/graalvm/${GRAALVM_VERSION%%.*}/arch
     JDIR=$(ls -d graalvm-jdk-${GRAALVM_VERSION}* | tail -n 1) && \
     mkdir ${JDIR}/languages && \
     update-alternatives --install /usr/bin/java java /usr/lib/jvm/${JDIR}/bin/java 92100
+RUN wget --quiet https://github.com/oracle/graalpython/releases/download/graal-${GRAALPY_VERSION}/graalpy-jvm-${GRAALPY_VERSION}-linux-amd64.tar.gz && \
+    tar xvzf graalpy-jvm-${GRAALPY_VERSION}-linux-amd64.tar.gz && \
+    rm -f graalpy-jvm-${GRAALPY_VERSION}-linux-amd64.tar.gz && \
+    mv graalpy-${GRAALPY_VERSION}-linux-amd64 graalpy
 
 FROM debian-graalvm AS builder
 ARG NETSHOT_VERSION


### PR DESCRIPTION
The ability to use `graalpy` was removed from Netshot for any version >= 0.20.0 (see f82a7c3a)

This PR downloads the jvm binary directly from the [oracle repository](https://github.com/oracle/graalpython/releases/)

This was tested with Netshot 0.21.2 and Graalpy 24.2.1.

For the record, I also suggest the following diff in [this page of the Wiki](https://github.com/netfishers-onl/Netshot/wiki/Python-virtualenv-for-additional-packages)

```diff
This is experimental. Requires Netshot 0.16.2 or later.

su - netshot -s /bin/bash
cd /usr/local/netshot
mkdir python && cd python
- graalpython -m venv venv
+ graalpython -m venv venv  # For versions between 0.16.2 and 0.20.0 (excluded)
+ /usr/lib/jvm/graalpy/bin/graalpy -m venv venv  # For versions superior to 0.21.2
source venv/bin/activate
/usr/local/netshot/python/venv/bin/graalpy -m pip install --upgrade pip
pip install [some package]

