### PR TITLE
fix(driver): :bug: FortiOS: support period characters in basic prompt position indicator

### DIFF
--- a/src/main/resources/drivers/Fortinet_FortiOS.js
+++ b/src/main/resources/drivers/Fortinet_FortiOS.js
@@ -24,7 +24,7 @@ var Info = {
 	name: "FortinetFortiOS", /* Unique identifier of the driver within Netshot. */
 	description: "Fortinet FortiOS", /* Description to be used in the UI. */
 	author: "Netshot Team",
-	version: "6.0" /* Version will appear in the Admin tab. */
+	version: "6.2" /* Version will appear in the Admin tab. */
 };
 
 /**
@@ -120,7 +120,7 @@ var CLI = {
 		}
 	},
 	basic: { /* The basic FortiOS prompt. */
-		prompt: /^[A-Za-z0-9_\-\~]+?\s(\([A-Za-z0-9_\-\~]+?\)\s)?[#$]\s?$/,
+		prompt: /^[A-Za-z0-9_\-\~]+?\s(\([A-Za-z0-9_\-\~\.]+?\)\s)?[#$]\s?$/,
 		error: /^(Unknown action|Command fail)/m,
 		pager: { /* 'pager': define how to handle the pager for long outputs. */
 			match: /^--More-- /,


### PR DESCRIPTION
Hi,

This small pull request fixes an issue with the FortiOS driver.

It currently does not accept the period character in the "basic prompt" mode, which leads to timeouts while waiting for the prompt.

Periods are present in various interfaces names, like L2TP tunnels, NPU sub-interfaces, etc.:
```
MYFIREWALL # conf global

MYFIREWALL (global) # config system interface

MYFIREWALL (interface) # edit l2t.TESTIF

MYFIREWALL (l2t.TESTIF) #
```

The last line was not matched by the previous regular expression.