### PR TITLE
Rest API : Add serialNumber to RsLightDevice

### DIFF
--- a/src/main/java/net/netshot/netshot/rest/RestService.java
+++ b/src/main/java/net/netshot/netshot/rest/RestService.java
@@ -1584,6 +1584,13 @@ public class RestService extends Thread {
 		@Setter
 		protected Boolean configCompliant;
 
+		/** The serial number. */
+		@Getter(onMethod = @__({
+			@XmlElement, @JsonView(DefaultView.class)
+		}))
+		@Setter
+		protected String serialNumber;
+
 		/** The software level. */
 		@Getter(onMethod = @__({
 			@XmlElement, @JsonView(DefaultView.class)
@@ -1629,6 +1636,7 @@ public class RestService extends Thread {
 				+ "case when (d.eolDate < current_date()) then true else false end,  "
 				+ "case when (d.eosDate < current_date()) then true else false end, "
 				+ "case when (select count(cr) from CheckResult cr where cr.key.device = d and cr.result = :nonConforming) = 0 then true else false end, "
+				+ "d.serialNumber, "
 				+ "d.softwareLevel "
 				+ ") from Device d";
 			if (groupId != null) {
@@ -3021,6 +3029,7 @@ public class RestService extends Thread {
 					+ "case when (d.eolDate < current_date()) then true else false end,  "
 					+ "case when (d.eosDate < current_date()) then true else false end, "
 					+ "case when (select count(cr) from CheckResult cr where cr.key.device = d and cr.result = :nonConforming) = 0 then true else false end, "
+					+ "d.serialNumber, "
 					+ "d.softwareLevel) " + finder.getHql(), RsLightDevice.class);
 				finder.setVariables(query);
 				query.setParameter("nonConforming", CheckResult.ResultOption.NONCONFORMING);
@@ -5304,9 +5313,9 @@ public class RestService extends Thread {
 		private Date expirationDate;
 
 		public RsLightExemptedDevice(long id, String name, String family, Network4Address mgmtAddress, Status status,
-			String driver, Boolean eol, Boolean eos, Boolean configCompliant, ConformanceLevel softwareLevel,
+			String driver, Boolean eol, Boolean eos, Boolean configCompliant, String serialNumber, ConformanceLevel softwareLevel,
 			Date expirationDate) {
-			super(id, name, family, mgmtAddress, status, driver, eol, eos, configCompliant, softwareLevel);
+			super(id, name, family, mgmtAddress, status, driver, eol, eos, configCompliant, serialNumber, softwareLevel);
 			this.expirationDate = expirationDate;
 		}
 
@@ -5346,6 +5355,7 @@ public class RestService extends Thread {
 					+ "case when (d.eolDate < current_date()) then true else false end,  "
 					+ "case when (d.eosDate < current_date()) then true else false end, "
 					+ "case when (select count(cr) from CheckResult cr where cr.key.device = d and cr.result = :nonConforming) = 0 then true else false end, "
+					+ "d.serialNumber, "
 					+ "d.softwareLevel, "
 					+ "e.expirationDate as expirationDate "
 					+ ") from Exemption e join e.key.device d where e.key.rule.id = :id",
@@ -5917,9 +5927,9 @@ public class RestService extends Thread {
 		private ResultOption result;
 
 		public RsLightPolicyRuleDevice(long id, String name, String family, Network4Address mgmtAddress, Status status,
-			String driver, Boolean eol, Boolean eos, Boolean configCompliant, ConformanceLevel softwareLevel,
+			String driver, Boolean eol, Boolean eos, Boolean configCompliant, String serialNumber, ConformanceLevel softwareLevel,
 			String policyName, String ruleName, Date checkDate, ResultOption result) {
-			super(id, name, family, mgmtAddress, status, driver, eol, eos, configCompliant, softwareLevel);
+			super(id, name, family, mgmtAddress, status, driver, eol, eos, configCompliant, serialNumber, softwareLevel);
 			this.ruleName = ruleName;
 			this.policyName = policyName;
 			this.checkDate = checkDate;
@@ -5970,6 +5980,7 @@ public class RestService extends Thread {
 				+ "case when (d.eolDate < current_date()) then true else false end,  "
 				+ "case when (d.eosDate < current_date()) then true else false end, "
 				+ "case when (select count(cr) from CheckResult cr where cr.key.device = d and cr.result = :nonConforming) = 0 then true else false end, "
+				+ "d.serialNumber, "
 				+ "d.softwareLevel, "
 				+ "p.name as policyName, "
 				+ "r.name as ruleName, "
@@ -6066,6 +6077,7 @@ public class RestService extends Thread {
 						+ "case when (d.eolDate < current_date()) then true else false end,  "
 						+ "case when (d.eosDate < current_date()) then true else false end, "
 						+ "case when (select count(cr) from CheckResult cr where cr.key.device = d and cr.result = :nonConforming) = 0 then true else false end, "
+						+ "d.serialNumber, "
 						+ "d.softwareLevel, "
 						+ "p.name as policyName, "
 						+ "r.name as ruleName, "
@@ -6133,6 +6145,7 @@ public class RestService extends Thread {
 							+ "case when (d.eolDate < current_date()) then true else false end,  "
 							+ "case when (d.eosDate < current_date()) then true else false end, "
 							+ "case when (select count(cr) from CheckResult cr where cr.key.device = d and cr.result = :nonConforming) = 0 then true else false end, "
+							+ "d.serialNumber, "
 							+ "d.softwareLevel "
 							+ ") from Device d where d." + type + "Date is null and d.status = :enabled",
 						RsLightDevice.class)
@@ -6154,6 +6167,7 @@ public class RestService extends Thread {
 							+ "case when (d.eolDate < current_date()) then true else false end,  "
 							+ "case when (d.eosDate < current_date()) then true else false end, "
 							+ "case when (select count(cr) from CheckResult cr where cr.key.device = d and cr.result = :nonConforming) = 0 then true else false end, "
+							+ "d.serialNumber, "
 							+ "d.softwareLevel "
 							+ ") from Device d where date(d." + type + "Date) = :eoxDate and d.status = :enabled",
 						RsLightDevice.class)
@@ -6901,6 +6915,7 @@ public class RestService extends Thread {
 						+ "case when (d.eolDate < current_date()) then true else false end,  "
 						+ "case when (d.eosDate < current_date()) then true else false end, "
 						+ "case when (select count(cr) from CheckResult cr where cr.key.device = d and cr.result = :nonConforming) = 0 then true else false end, "
+						+ "d.serialNumber, "
 						+ "d.softwareLevel "
 						+ ") from Device d join d.groupMemberships gm where gm.key.group.id = :id and d.softwareLevel = :level and d.status = :enabled" + domainFilter,
 					RsLightDevice.class)
@@ -6945,9 +6960,9 @@ public class RestService extends Thread {
 		private Date lastFailure;
 
 		public RsLightAccessFailureDevice(long id, String name, String family, Network4Address mgmtAddress, Status status,
-			String driver, Boolean eol, Boolean eos, Boolean configCompliant, ConformanceLevel softwareLevel,
+			String driver, Boolean eol, Boolean eos, Boolean configCompliant, String serialNumber, ConformanceLevel softwareLevel,
 			Date lastSuccess, Date lastFailure) {
-			super(id, name, family, mgmtAddress, status, driver, eol, eos, configCompliant, softwareLevel);
+			super(id, name, family, mgmtAddress, status, driver, eol, eos, configCompliant, serialNumber, softwareLevel);
 			this.lastSuccess = lastSuccess;
 			this.lastFailure = lastFailure;
 		}
@@ -7005,6 +7020,7 @@ public class RestService extends Thread {
 					+ "case when (d.eolDate < current_date()) then true else false end,  "
 					+ "case when (d.eosDate < current_date()) then true else false end, "
 					+ "case when (select count(cr) from CheckResult cr where cr.key.device = d and cr.result = :nonConforming) = 0 then true else false end, "
+					+ "d.serialNumber, "
 					+ "d.softwareLevel, "
 					+ "(select max(t.executionDate) from TakeSnapshotTask t where t.device = d and t.status = :success) as lastSuccess, "
 					+ "(select max(t.executionDate) from TakeSnapshotTask t where t.device = d and t.status = :failure) as lastFailure "

--- a/src/test/java/net/netshot/netshot/RestServiceTest.java
+++ b/src/test/java/net/netshot/netshot/RestServiceTest.java
@@ -1408,6 +1408,7 @@ public class RestServiceTest {
 						.put("eol", device1.isEndOfLife())
 						.put("eos", device1.isEndOfSale())
 						.put("configCompliant", device1.isCompliant())
+						.put("serialNumber", device1.getSerialNumber())
 						.put("softwareLevel", device1.getSoftwareLevel().toString()),
 					deviceNode1,
 					"Retrieved device doesn't match expected object");
@@ -1636,6 +1637,7 @@ public class RestServiceTest {
 					.put("mgmtAddress", device2.getMgmtAddress().getIp())
 					.put("status", device2.getStatus().toString())
 					.put("driver", device2.getDriver())
+					.put("serialNumber", device2.getSerialNumber())
 					.put("eol", device2.isEndOfLife())
 					.put("eos", device2.isEndOfSale())
 					.put("configCompliant", device2.isCompliant())


### PR DESCRIPTION
Hi,

This PR adds the `serialNumber ` attribute to the `RsLightDevice` class used when listing devices using the Rest API.

This might help reducing API calls when listing devices for exports or cross platforms cycle checks.

This affects every subclasses or `RsLightDevice`:
- `RsSearchResults`
- `RsLightExemptedDevice`
- `RsLightPolicyRuleDevice`
- `RsLightAccessFailureDevice`