### PR TITLE
Fix for Fortinet_FortiOS.js: TypeError Version.match is not a function

### DIFF
--- a/src/main/resources/drivers/Fortinet_FortiOS.js
+++ b/src/main/resources/drivers/Fortinet_FortiOS.js
@@ -206,7 +206,7 @@ function snapshot(cli, device, config) {
 	const showHa = cli.command("show full-configuration system ha | grep .");
 
 	if (vdomMode) {
-		if (!useScp && version.match(/^6\.2\..*/)) {
+		if (!useScp && osVersion.match(/^6\.2\..*/)) {
 			// In 6.2, some config blocks are missing from the root 'show'
 			// We'll take a 'show' in 'config global' mode and replace
 			globalConfig = cli.command("show | grep .", { timeout: 120000 });

--- a/src/main/resources/drivers/Fortinet_FortiOS.js
+++ b/src/main/resources/drivers/Fortinet_FortiOS.js
@@ -24,7 +24,7 @@ const Info = {
 	name: "FortinetFortiOS", /* Unique identifier of the driver within Netshot. */
 	description: "Fortinet FortiOS", /* Description to be used in the UI. */
 	author: "Netshot Team",
-	version: "7.2" /* Version will appear in the Admin tab. */
+	version: "7.3" /* Version will appear in the Admin tab. */
 };
 
 /**


### PR DESCRIPTION
Fix for Fortinet_FortiOS.js: TypeError Version.match is not a function at Fortinet_FortiOS.js:209:18 #402